### PR TITLE
Added flags to enable DeviceAddress allocation

### DIFF
--- a/src/VulkanSuballocator.cpp
+++ b/src/VulkanSuballocator.cpp
@@ -88,9 +88,13 @@ namespace rtxmu
         vk::MemoryRequirements memoryRequirements = allocator->device.getBufferMemoryRequirements(m_buffer, m_dispatchLoader);
         uint32_t memoryTypeIndex = getMemoryIndex(allocator->physicalDevice, memoryRequirements.memoryTypeBits, propFlags, heapflags);
 
+        auto allocFlags = vk::MemoryAllocateFlagsInfo();
+        allocFlags.flags |= vk::MemoryAllocateFlagBits::eDeviceAddress;
+        
         auto memoryInfo = vk::MemoryAllocateInfo()
             .setAllocationSize(size)
-            .setMemoryTypeIndex(memoryTypeIndex);
+            .setMemoryTypeIndex(memoryTypeIndex)
+            .setPNext(&allocFlags);
 
         m_memory = allocator->device.allocateMemory(memoryInfo, nullptr, VkBlock::getDispatchLoader());
         allocator->device.bindBufferMemory(m_buffer, m_memory, 0, VkBlock::getDispatchLoader());


### PR DESCRIPTION
Added a simple struct to specify that the allocation should have vk::MemoryAllocateFlagBits::eDeviceAddress flag set, because when using this library with acceleration structures, it is safe to assume that the user has VK_KHR_buffer_device_address enabled. This also makes a validation warning go away in Vulkan 1.2 (If buffer was created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT bit set, memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set) when it calls bindBufferMemory at line 100.