### PR TITLE
Cleanup resources

### DIFF
--- a/include/rtxmu/Suballocator.h
+++ b/include/rtxmu/Suballocator.h
@@ -90,6 +90,16 @@ namespace rtxmu
             m_allocator = allocator;
         }
 
+        virtual ~Suballocator()
+        {
+            uint32_t blockIndex = 0;
+            for (BlockDesc* blockDesc : m_blocks)
+            {
+                blockDesc->block.free(m_allocator);
+                m_blocks.erase(m_blocks.begin() + blockIndex);
+                blockIndex++;
+            }
+        }
         SubAllocation allocate(uint64_t size)
         {
             // Align allocation
@@ -352,4 +362,3 @@ namespace rtxmu
     };
 
 }// end rtxmu namespace
-


### PR DESCRIPTION
This PR aims to cleanup the allocations after the Allocator has been destroyed to prevent memory leaks and I have also implemented logic to destroy acceleration structures when `VkAccelStructManager::RemoveAccelerationStructures` is called. There is also a change where `resultGpuMemory.block.m_asHandle` is destroyed after compaction has been performed, this happens when   `VkAccelStructManager::GarbageCollection` is called.